### PR TITLE
Add AWS credentials profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ output "docker_hub_user" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region to use | string | `us-east-1` | no |
+| aws_profile | AWS credentials profile to use | string | `` | no |
 | secret_id | Specifies the secret containing the version that you want to retrieve. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. | string | - | yes |
 | version_id | Specifies the unique identifier of the version of the secret that you want to retrieve. Overrides version_stage | string | `` | no |
 | version_stages | Specifies the secret version that you want to retrieve by the staging label attached to the version. Defaults to AWSCURRENT | string | `AWSCURRENT` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   version = "~> 1.40"
   region = "${var.aws_region}"
+  profile = "${var.aws_profile}"
 }
 
 data "aws_secretsmanager_secret_version" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
+variable "aws_profile" {
+  description = "AWS profile to use (if any)"
+  default = ""
+}
+
 variable "secret_id" {
   description = "Specifies the secret containing the version that you want to retrieve. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret."
 }


### PR DESCRIPTION
Add AWS credentials profile support to support setups where multiple AWS accounts are present.

Does not change the default behaviour for users as profile is unset by default.